### PR TITLE
adding assignee when labeled task.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   TOUCHPOINT_TAGS:
     description: 'The id value of the touchpoint reason.'
     required: true
-  TOTANGO_USER_NAME:
+  TASK_ASSIGNEE:
     description: 'The email value used for testing - will be changed later after testing'
   repo-token:
     description: 'GitHub Repo Token for auth'

--- a/index.js
+++ b/index.js
@@ -16,8 +16,7 @@ try {
   const ACTIVITY_TYPE = core.getInput('ACTIVITY_TYPE');
   const TOUCHPOINT_TAGS = core.getInput('TOUCHPOINT_TAGS');
   const TOUCHPOINT_TYPE = core.getInput('TOUCHPOINT_TYPE');
-  const TOTANGO_USER_NAME = core.getInput('TOTANGO_USER_NAME');
-  const TOTANGO_TASK_ASSIGNEES = core.getInput('TOTANGO_TASK_ASSIGNEE') //comma separated list of assignees. up to 10
+  const TASK_ASSIGNEE = core.getInput('TASK_ASSIGNEE');
   const GITHUB_TOKEN = core.getInput('repo-token');
   const octokit = github.getOctokit(GITHUB_TOKEN);
   // Fetch the payload from the event
@@ -131,8 +130,6 @@ function create_touchpoint(subject, body) {
 }
 
 function create_task(subject, body_array) {
-  console.log('Adding Assignees to issue')
-  github.issue.addAssignees({TOTANGO_TASK_ASSIGNEES})
   var request = require('request');
   request.post(TOTANGO_TASK_URL, {
       headers: {
@@ -140,7 +137,7 @@ function create_task(subject, body_array) {
       },
       form: {
         account_id: ACCOUNT_ID,
-        assignee: TOTANGO_USER_NAME, //TODO : get assignee from issue. If no assignee, get CSA/CSM from totango account and add
+        assignee: TASK_ASSIGNEE, //TODO : get assignee from issue. If no assignee, get CSA/CSM from totango account and add
         description: body_array[0],
         activity_type_id: DEFAULT_TASK_ACTIVITY,
         priority: body_array[1],

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ try {
   // Constants
   const DEFAULT_PRIORITY = 2 //Indicates "Normal" priority for tasks;
   const DEFAULT_TASK_ACTIVITY = 'support';
-  //where 12096e5 is the magic number for 14 days in milliseconds and the format is YYYY-MM-DD 
+  //where 12096e5 is the magic number for 14 days in milliseconds and the format is YYYY-MM-DD
   const DEFAULT_DUE_DATE = new Date(Date.now() + 12096e5).toISOString().substring(0, 10);
   const TOTANGO_TOUCHPOINTS_URL = 'https://api.totango.com/api/v3/touchpoints/';
   const TOTANGO_TASK_URL = 'https://api.totango.com/api/v3/tasks'
@@ -17,6 +17,7 @@ try {
   const TOUCHPOINT_TAGS = core.getInput('TOUCHPOINT_TAGS');
   const TOUCHPOINT_TYPE = core.getInput('TOUCHPOINT_TYPE');
   const TOTANGO_USER_NAME = core.getInput('TOTANGO_USER_NAME');
+  const TOTANGO_TASK_ASSIGNEES = core.getInput('TOTANGO_TASK_ASSIGNEE') //comma separated list of assignees. up to 10
   const GITHUB_TOKEN = core.getInput('repo-token');
   const octokit = github.getOctokit(GITHUB_TOKEN);
   // Fetch the payload from the event
@@ -28,7 +29,7 @@ try {
 
   const event_action = github.context.payload.action;
   console.log(`Event Action is: ${event_action}`);
-  
+
   // Build payload body
   if (github.context.eventName === 'issues') {
 
@@ -71,7 +72,7 @@ try {
         body_array[1] = DEFAULT_PRIORITY;
         body_array[2] = DEFAULT_DUE_DATE;
       }
-      
+
       if (label['name'] === 'task') {
         create_task(subject, body_array);
       }
@@ -130,6 +131,8 @@ function create_touchpoint(subject, body) {
 }
 
 function create_task(subject, body_array) {
+  console.log('Adding Assignees to issue')
+  github.issue.addAssignees({TOTANGO_TASK_ASSIGNEES})
   var request = require('request');
   request.post(TOTANGO_TASK_URL, {
       headers: {
@@ -139,7 +142,7 @@ function create_task(subject, body_array) {
         account_id: ACCOUNT_ID,
         assignee: TOTANGO_USER_NAME, //TODO : get assignee from issue. If no assignee, get CSA/CSM from totango account and add
         description: body_array[0],
-        activity_type_id: DEFAULT_TASK_ACTIVITY, 
+        activity_type_id: DEFAULT_TASK_ACTIVITY,
         priority: body_array[1],
         title: subject,
         status: 'open',


### PR DESCRIPTION
This PR is only changing the name of the assignees to `TASK_ASSIGNEE`. With our move to using secrets or a config file, the work is already completed by @rockin-robinson previous changes
Signed-off-by: Jeff Brimager <sam1el@github.com>