### PR TITLE
Rename REPO_TOKEN to GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The following `inputs` are used by this Action.  These values should be availabl
 
   When a task is created in Totango, this value will be the assignee for the task. Must be the email associated with Totango sign up (Totango user name). This value is also used as the submitter for a touchpoint.
 
-* `REPO_TOKEN`: **Required**, `string`
+* `GITHUB_TOKEN`: **Required**, `string`
 
   The Auto Generated GitHub Auth token for actions
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: true
   TASK_ASSIGNEE:
     description: 'The email value used for testing - will be changed later after testing'
-  REPO_TOKEN:
+  GITHUB_TOKEN:
     description: 'GitHub Repo Token for auth'
     required: true
 outputs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -55232,7 +55232,7 @@ const TASK_ASSIGNEE = core.getInput('TASK_ASSIGNEE');
 if (!validator.isEmail(TASK_ASSIGNEE)) {
   core.setFailed('TASK_ASSIGNEE must be a valid email address');
 }
-const GITHUB_TOKEN = core.getInput('REPO_TOKEN');
+const GITHUB_TOKEN = core.getInput('GITHUB_TOKEN');
 if (typeof GITHUB_TOKEN === 'undefined') {
   core.setFailed('GITHUB_TOKEN is required but not present.');
 }

--- a/examples/workflow_example.yml
+++ b/examples/workflow_example.yml
@@ -21,4 +21,4 @@ jobs:
           TOUCHPOINT_TAGS: ${{ vars.TOUCHPOINT_TAGS }}
           TOUCHPOINT_TYPE: ${{ vars.TOUCHPOINT_TYPE }}
           TASK_ASSIGNEE: ${{ vars.TASK_ASSIGNEE }}
-          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/totango.js
+++ b/src/totango.js
@@ -36,7 +36,7 @@ const TASK_ASSIGNEE = core.getInput('TASK_ASSIGNEE');
 if (!validator.isEmail(TASK_ASSIGNEE)) {
   core.setFailed('TASK_ASSIGNEE must be a valid email address');
 }
-const GITHUB_TOKEN = core.getInput('REPO_TOKEN');
+const GITHUB_TOKEN = core.getInput('GITHUB_TOKEN');
 if (typeof GITHUB_TOKEN === 'undefined') {
   core.setFailed('GITHUB_TOKEN is required but not present.');
 }


### PR DESCRIPTION
The GITHUB_TOKEN is required to be passed in as an input for a javascript action, so there didn't seem to be a way to simplify this further.

Tested on both Issues and Tasks ✅ 