### PR TITLE
Comments to Totango Follow Ups Feature and Doc Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The contents of this repository are community-maintained and are not a direct co
 ## Limitations and Known Issues
 
 * See [Issues](https://github.com/jmassardo/issues-to-totango/issues) for current bugs (labeled `[bug]`)
-* Logic for handling comments on issues has not been implemented
+* Logic for editing comments on issues has not been handled
 
 Feature requests are welcome. Please log an issue in this repo for new requests.
 
 ## Usage
 
-This action should be used in a repository in combination with Issues, triggering from `issues` event types.
+This action should be used in a repository in combination with Issues, triggering from `issues` and `issue_comment` event types.
 
 ### Migrating from v1.2 to v2.0
 
@@ -106,6 +106,7 @@ This action supports the following triggers:
   * edited
   * labeled
 * issue_comments
+  * created
 
 ### Interacting with Issues
 
@@ -118,6 +119,7 @@ on:
   issues:
     types: [closed, labeled, edited]
   issue_comment:
+    types: [created]
 
 jobs:
   totango-integration:
@@ -135,7 +137,7 @@ jobs:
           TOUCHPOINT_TAGS: ${{ vars.TOUCHPOINT_TAGS }}
           TOUCHPOINT_TYPE: ${{ vars.TOUCHPOINT_TYPE }}
           TASK_ASSIGNEE: ${{ vars.TASK_ASSIGNEE }}
-          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ This action should be used in a repository in combination with Issues, triggerin
 
 If currently using v1.2 (or below), you will need to take the following steps to use v2.0:
 
-* Create the labels `task` and `touchpoint` in the repo where the action will be run. See [manging labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#creating-a-label) for more information.
+* Create the labels `task` and `touchpoint` in the repo where the action will be run. See [managing labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#creating-a-label) for more information.
 * (Optional) Remove the `totango-sync` label from the repo. See [deleting a label](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#deleting-a-label) for help.
 * Edit the original workflow file to match [this workflow](https://github.com/jmassardo/issues-to-totango/blob/version2.0/examples/workflow_example.yml) and change the VERSION to v2.0 in the workflow steps. Commit it to the repo.
 * Add the following [task template](https://github.com/jmassardo/issues-to-totango/blob/version2.0/examples/task_issue_template_example.md)  to the ISSUE_TEMPLATES folder in the repo and commit
-* Add a configuration variable to the repo for the TASK_ASIGNEE input. This should be the email in Totango of the user who will be assigned tasks. For help, see [Creating configuration variables for a repository](https://docs.github.com/en/enterprise-cloud@latest/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository)
+* Add a configuration variable to the repo for the TASK_ASSIGNEE input. This should be the email in Totango of the user who will be assigned tasks. For help, see [Creating configuration variables for a repository](https://docs.github.com/en/enterprise-cloud@latest/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository)
 * (Optional) Change the following repo secrets to configuration variables:
   * ACTIVITY_TYPE
   * TOUCHPOINT_TAGS

--- a/__test__/totango.test.js
+++ b/__test__/totango.test.js
@@ -12,9 +12,11 @@ jest.mock('../src/totango', () => ({
     format_body: jest.fn(),
     update_task: jest.fn(),
     get_task_form_data: jest.fn(),
+    create_follow_up: jest.fn()
   },
   labeled: jest.fn(),
   edited: jest.fn(),
+  commented: jest.fn(),
 }));
 
 // Mock the github context
@@ -64,6 +66,17 @@ describe('create_task', () => {
   });
 });
 
+// write test for create_follow_up
+describe('create_follow_up', () => {
+  it('should call create_follow_up', async () => {
+    const { create_follow_up, } = totangoPrivate;
+    await create_follow_up('Test subject', 'Test content', '12345');
+    expect(create_follow_up).toHaveBeenCalled();
+    expect(create_follow_up).toHaveBeenCalledWith('Test subject', 'Test content', '12345');
+  });
+});
+
+
 // write test for format_body
 describe('format_body', () => {
   it('should call format_body', async () => {
@@ -91,6 +104,16 @@ describe('edited', () => {
     await edited({ issue: github.context.payload.issue, });
     expect(edited).toHaveBeenCalled();
     expect(edited).toHaveBeenCalledWith({ issue: github.context.payload.issue, });
+  });
+});
+
+//write test for commented
+describe('commented', () => {
+  it('should call commented', async () => {
+    const { commented, } = require('../src/totango');
+    await commented({ issue: github.context.payload.issue, comment: github.context.payload.comment, });
+    expect(commented).toHaveBeenCalled();
+    expect(commented).toHaveBeenCalledWith({ issue: github.context.payload.issue, comment: github.context.payload.comment, });
   });
 });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -55814,16 +55814,6 @@ async function closed({ issue }) {
   }
 }
 
-// async function commented({ _issue, _comment }) {
-//   // This function is not currently performing any actions
-//   // let subject = 'Issue #: ' + issue['title'] + ' was commented on';
-//   // let body = format_body(comment, issue['html_url'], 'commented', issue['number']);
-//   console.log('Issue was commented on');
-//   return new Promise((resolve, _reject) => {
-//     resolve();
-//   });
-// }
-
 // Exports for testing
 const totangoPrivate = {
   parse_to_array,

--- a/examples/workflow_example.yml
+++ b/examples/workflow_example.yml
@@ -4,6 +4,7 @@ on:
   issues:
     types: [closed, labeled, edited]
   issue_comment:
+    types: [created]
 
 jobs:
   totango-integration:

--- a/src/index.js
+++ b/src/index.js
@@ -51,15 +51,16 @@ if (github.context.eventName === 'issues') {
     console.log(action);
   }
 } else if (github.context.eventName === 'issue_comment') {
+  if (event_action === 'created') {
 
-  let comment = github.context.payload.comment;
+    let comment = github.context.payload.comment;
 
-  let action = totango.commented({
-    issue: issue,
-    comment: comment,
-  });
-
-  console.log(action);
+    let action = totango.commented({
+      issue: issue,
+      comment: comment,
+    });
+    console.log(action);
+  }
 } else {
 
   core.setFailed('Unsupported event type. Please use the  `issues` or `issue_comment` event type.');

--- a/src/totango.js
+++ b/src/totango.js
@@ -567,6 +567,9 @@ async function commented({ issue, comment }) {
 // Function to create_follow_up in Totango
 async function create_follow_up(subject, content, parent_id) {
   console.log('Creating Follow Up in Totango...');
+  console.log('Subject: ' + subject);
+  console.log('Content: ' + content);
+  console.log('Parent ID: ' + parent_id);
   return new Promise((resolve, reject) => {
     try {
       request.post(`${TOTANGO_TOUCHPOINTS_URL}`, {
@@ -592,7 +595,7 @@ async function create_follow_up(subject, content, parent_id) {
         let follow_up_id = (JSON.parse(response.body))['id'];
         // Output a message to the console and an Action output
         console.log(`Successfully created follow up: ${follow_up_id}`);
-        core.setOutput('task_id', follow_up_id);
+        core.setOutput('follow_up_id', follow_up_id);
         resolve(follow_up_id);
       });
     } catch (error) {

--- a/src/totango.js
+++ b/src/totango.js
@@ -618,16 +618,6 @@ async function closed({ issue }) {
   }
 }
 
-// async function commented({ _issue, _comment }) {
-//   // This function is not currently performing any actions
-//   // let subject = 'Issue #: ' + issue['title'] + ' was commented on';
-//   // let body = format_body(comment, issue['html_url'], 'commented', issue['number']);
-//   console.log('Issue was commented on');
-//   return new Promise((resolve, _reject) => {
-//     resolve();
-//   });
-// }
-
 // Exports for testing
 const totangoPrivate = {
   parse_to_array,

--- a/src/totango.js
+++ b/src/totango.js
@@ -542,7 +542,7 @@ async function commented({ issue, comment }) {
   if (comment['user']['type'] === 'User') {
     let issue_body = issue['body'];
     let subject = issue['title'] + ' was commented on';
-    let comment_body = format_body(comment, issue['html_url'], 'commented', issue['number']);
+    let comment_body = await format_body(comment, issue['html_url'], 'commented', issue['number']);
     let tp_id = issue_body.match(/touchpoint_ID: (\d+)/); // Fetches the first touchpoint ID from the issue body
     if (tp_id != null) {
       var parent_id = tp_id[1];

--- a/src/totango.js
+++ b/src/totango.js
@@ -569,7 +569,6 @@ async function create_follow_up(subject, content, parent_id) {
   console.log('Creating Follow Up in Totango...');
   console.log('Subject: ' + subject);
   console.log('Content: ' + content);
-  console.log('Parent ID: ' + parent_id);
   return new Promise((resolve, reject) => {
     try {
       request.post(`${TOTANGO_TOUCHPOINTS_URL}`, {
@@ -592,7 +591,7 @@ async function create_follow_up(subject, content, parent_id) {
           core.setFailed(`Failed to create Follow Up: ${response.statusCode}`);
           reject(`Failed to create Follow Up: ${response.statusCode}`);
         }
-        let follow_up_id = (JSON.parse(response.body))['id'];
+        let follow_up_id = (JSON.parse(response.body))['note']['id'];
         // Output a message to the console and an Action output
         console.log(`Successfully created follow up: ${follow_up_id}`);
         core.setOutput('follow_up_id', follow_up_id);

--- a/src/totango.js
+++ b/src/totango.js
@@ -131,18 +131,31 @@ async function add_html_comment({issue, type, id}) {
       // Create an authenticated GitHub client
       let octokit = github.getOctokit(GITHUB_TOKEN);
 
-      // call get_issue_body to get the issue body
-      get_issue_body({issue}).then((body) => {
-
-        octokit.rest.issues.update({
+      // If the type is a follow_up, update the comment with the follow_up_id
+      if (type === 'follow_up') {
+        let comment_id = issue['id'];
+        octokit.rest.issues.updateComment({
           owner: github.context.repo.owner,
           repo: github.context.repo.repo,
-          issue_number: issue['number'],
-          body: `${body}\n\n<!-- ${type}_ID: ${id} -->`,
+          comment_id: comment_id,
+          body: `${issue['body']}\n\n<!-- ${type}_ID: ${id} -->`,
         });
-        console.log(`Updated issue ${issue['number']} with ${type}_ID: ${id}`);
+        console.log(`Updated comment ${comment_id} with ${type}_ID: ${id}`);
         resolve();
-      });
+      } else {
+        // call get_issue_body to get the issue body
+        get_issue_body({issue}).then((body) => {
+
+          octokit.rest.issues.update({
+            owner: github.context.repo.owner,
+            repo: github.context.repo.repo,
+            issue_number: issue['number'],
+            body: `${body}\n\n<!-- ${type}_ID: ${id} -->`,
+          });
+          console.log(`Updated issue ${issue['number']} with ${type}_ID: ${id}`);
+          resolve();
+        });
+      }
     } catch (error) {
       console.log(error);
       reject(error);
@@ -517,6 +530,78 @@ async function get_task_form_data({ body }){
   return body_array;
 }
 
+// Function to create a follow up in Totango from an issue comment
+async function commented({ issue, comment }) {
+  // Check to see if the comment is from a bot
+  if (comment['user']['login'] === 'github-actions[bot]') {
+    return new Promise((resolve, _reject) => {
+      resolve();
+    });
+  }
+  // Check to see if the comment is from a user
+  if (comment['user']['type'] === 'User') {
+    let issue_body = issue['body'];
+    let subject = issue['title'] + ' was commented on';
+    let comment_body = format_body(comment, issue['html_url'], 'commented', issue['number']);
+    let tp_id = issue_body.match(/touchpoint_ID: (\d+)/); // Fetches the first touchpoint ID from the issue body
+    if (tp_id != null) {
+      var parent_id = tp_id[1];
+      console.log(`Parent id is: ${parent_id}`);
+
+      let follow_up_id = await create_follow_up(subject, comment_body, parent_id);
+      console.log('Commenting on github issue for follow up id');
+      await add_html_comment({
+        issue: comment,
+        type: 'follow_up',
+        id: follow_up_id,
+      });
+    } else {
+      core.setFailed(`Failed to find touchpoint ID in body: ${issue_body}`);
+    }
+    return new Promise((resolve, _reject) => {
+      resolve();
+    });
+  }
+}
+
+// Function to create_follow_up in Totango
+async function create_follow_up(subject, content, parent_id) {
+  console.log('Creating Follow Up in Totango...');
+  return new Promise((resolve, reject) => {
+    try {
+      request.post(`${TOTANGO_TOUCHPOINTS_URL}`, {
+        headers: {
+          'app-token': APP_TOKEN,
+        },
+        form: {
+          account_id: ACCOUNT_ID,
+          subject: subject,
+          content: content,
+          title: subject,
+          parentId: parent_id,
+          followUp: parent_id,
+        },
+      }, (error, response, _body) => {
+        if (error) {
+          core.setFailed(`Failed to create Follow Up: ${error}`);
+          reject(error);
+        } else if (response.statusCode < 200 || response.statusCode >= 300) {
+          core.setFailed(`Failed to create Follow Up: ${response.statusCode}`);
+          reject(`Failed to create Follow Up: ${response.statusCode}`);
+        }
+        let follow_up_id = (JSON.parse(response.body))['id'];
+        // Output a message to the console and an Action output
+        console.log(`Successfully created follow up: ${follow_up_id}`);
+        core.setOutput('task_id', follow_up_id);
+        resolve(follow_up_id);
+      });
+    } catch (error) {
+      console.log(error);
+      reject(error);
+    }
+  });
+}
+
 async function closed({ issue }) {
   console.log('Issue was closed');
   let body = issue['body'];
@@ -531,15 +616,15 @@ async function closed({ issue }) {
   }
 }
 
-async function commented({ _issue, _comment }) {
-  // This function is not currently performing any actions
-  // let subject = 'Issue #: ' + issue['title'] + ' was commented on';
-  // let body = format_body(comment, issue['html_url'], 'commented', issue['number']);
-  console.log('Issue was commented on');
-  return new Promise((resolve, _reject) => {
-    resolve();
-  });
-}
+// async function commented({ _issue, _comment }) {
+//   // This function is not currently performing any actions
+//   // let subject = 'Issue #: ' + issue['title'] + ' was commented on';
+//   // let body = format_body(comment, issue['html_url'], 'commented', issue['number']);
+//   console.log('Issue was commented on');
+//   return new Promise((resolve, _reject) => {
+//     resolve();
+//   });
+// }
 
 // Exports for testing
 const totangoPrivate = {
@@ -548,6 +633,7 @@ const totangoPrivate = {
   get_task_by_id,
   issue_has_totango_id,
   create_touchpoint,
+  create_follow_up,
   edit_touchpoint,
   update_task,
   get_event,


### PR DESCRIPTION
Changes:
* Implemented follow-up in Totango when issue is commented on
* Added tests to testing suite to call 'commented' and 'create_follow_up' functions
* Updated README and example workflow file
* Tested
Images from testing:
![image](https://user-images.githubusercontent.com/30062914/231553651-fc3b8dda-673a-46f3-bc59-8085c7bf2850.png)
![image](https://user-images.githubusercontent.com/30062914/231553947-9f3776e1-17aa-48cd-a950-24b35b302a3e.png)
